### PR TITLE
fix: 补全 small_cap_strategy.py 缺失的 logger 定义

### DIFF
--- a/easyxt_backtest/strategies/small_cap_strategy.py
+++ b/easyxt_backtest/strategies/small_cap_strategy.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import logging
+
+logger = logging.getLogger(__name__)
 """
 小市值策略 - 基于市值选股
 


### PR DESCRIPTION
修复 `SmallCapStrategy` / `SmallCapStrategyV2` 实例化时因未定义 `logger` 而抛出的 `NameError`。

问题复现：运行 `学习实例/04_策略回测.py` 时，在 `lesson_3_practical_demo` 中实例化 `SmallCapStrategy` 会触发：

```
NameError: name 'logger' is not defined
```

修复方式：在模块顶部参照 `grid_strategy.py` 和 `technical.py` 的写法，补全：

```python
import logging

logger = logging.getLogger(__name__)
```

已在本地验证：实例化 `SmallCapStrategy()` 不再报错。
